### PR TITLE
selection: Add option to loop cursor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,5 @@ linters-settings:
     default-signifies-exhaustive: true
 issues:
   exclude-use-default: false
+run:
+  skip-dirs-use-default: false

--- a/examples/selection_custom/main.go
+++ b/examples/selection_custom/main.go
@@ -58,6 +58,7 @@ func main() {
 	sp.FilterPrompt = "Filter by ID:"
 	sp.FilterPlaceholder = "Type to filter"
 	sp.PageSize = 3
+	sp.LoopCursor = true
 	sp.Filter = func(filter string, choice *selection.Choice) bool {
 		chosenArticle, _ := choice.Value.(article)
 
@@ -76,6 +77,7 @@ func main() {
 		return a.Name + " " + termenv.String("("+a.ID+")").Faint().String()
 	}
 	sp.ExtendedTemplateFuncs = map[string]interface{}{
+		// nolint:forcetypeassert
 		"name": func(c *selection.Choice) string { return c.Value.(article).Name },
 	}
 

--- a/selection/model.go
+++ b/selection/model.go
@@ -430,11 +430,12 @@ func (m *Model) scrollDown() {
 }
 
 func (m *Model) scrollToBottom() {
+	m.currentIdx = len(m.currentChoices) - 1
+
 	if m.PageSize <= 0 || m.availableChoices < m.PageSize {
 		return
 	}
 
-	m.currentIdx = len(m.currentChoices) - 1
 	m.scrollOffset = m.availableChoices - m.PageSize
 	m.currentChoices, m.availableChoices = m.filteredAndPagedChoices()
 }
@@ -450,11 +451,12 @@ func (m *Model) scrollUp() {
 }
 
 func (m *Model) scrollToTop() {
+	m.currentIdx = 0
+
 	if m.PageSize <= 0 || m.availableChoices < m.PageSize {
 		return
 	}
 
-	m.currentIdx = 0
 	m.scrollOffset = 0
 	m.currentChoices, m.availableChoices = m.filteredAndPagedChoices()
 }

--- a/selection/model_test.go
+++ b/selection/model_test.go
@@ -275,6 +275,136 @@ func TestSubmit(t *testing.T) {
 	test.AssertGoldenView(t, m, "submit.golden")
 }
 
+func TestLoopCursorTopToBottom(t *testing.T) {
+	t.Parallel()
+
+	choices := []string{
+		"a", "b", "c", "d", "lastelement",
+	}
+	lastElement := choices[len(choices)-1]
+
+	m := selection.NewModel(selection.New("foo:",
+		selection.Choices(choices)))
+	m.ColorProfile = termenv.TrueColor
+	m.LoopCursor = true
+
+	test.Run(t, m, tea.KeyUp)
+	assertNoError(t, m)
+
+	// nolint:forcetypeassert
+	if value := getChoice(t, m).Value; value.(string) != lastElement {
+		t.Fatalf("value did not loop to the last element %q but %q",
+			lastElement, value)
+	}
+
+	test.AssertGoldenView(t, m, "loop_top_to_bottom.golden")
+}
+
+func TestLoopCursorBottomToTop(t *testing.T) {
+	t.Parallel()
+
+	choices := []string{
+		"firstelement", "b", "c", "d", "lastelement",
+	}
+	firstElement := choices[0]
+	lastElement := choices[len(choices)-1]
+
+	m := selection.NewModel(selection.New("foo:",
+		selection.Choices(choices)))
+	m.ColorProfile = termenv.TrueColor
+	m.LoopCursor = true
+
+	test.Run(t, m, tea.KeyDown, tea.KeyDown, tea.KeyDown, tea.KeyDown)
+	assertNoError(t, m)
+
+	// nolint:forcetypeassert
+	if value := getChoice(t, m).Value; value.(string) != lastElement {
+		t.Fatalf("value did not loop to the last element before looping but %q",
+			value)
+	}
+
+	test.Update(t, m, tea.KeyDown)
+
+	// nolint:forcetypeassert
+	if value := getChoice(t, m).Value; value.(string) != firstElement {
+		t.Fatalf("value did not loop to the first element %q but %q",
+			firstElement, value)
+	}
+
+	test.AssertGoldenView(t, m, "loop_bottom_to_top.golden")
+}
+
+func TestLoopCursorTopToBottomPaged(t *testing.T) {
+	t.Parallel()
+
+	choices := []string{
+		"a", "b", "c", "d", "lastelement",
+	}
+	lastElement := choices[len(choices)-1]
+
+	m := selection.NewModel(selection.New("foo:",
+		selection.Choices(choices)))
+	m.ColorProfile = termenv.TrueColor
+	m.PageSize = 3
+	m.LoopCursor = true
+
+	test.Run(t, m)
+	assertNoError(t, m)
+
+	if strings.Contains(m.View(), lastElement) {
+		t.Fatalf("last element is already shown before looping")
+	}
+
+	test.Update(t, m, tea.KeyUp)
+
+	// nolint:forcetypeassert
+	if value := getChoice(t, m).Value; value.(string) != lastElement {
+		t.Fatalf("value did not loop to the last element %q but %q",
+			lastElement, value)
+	}
+
+	test.AssertGoldenView(t, m, "loop_top_to_bottom_paged.golden")
+}
+
+func TestLoopCursorBottomToTopPaged(t *testing.T) {
+	t.Parallel()
+
+	choices := []string{
+		"firstelement", "b", "c", "d", "lastelement",
+	}
+	firstElement := choices[0]
+	lastElement := choices[len(choices)-1]
+
+	m := selection.NewModel(selection.New("foo:",
+		selection.Choices(choices)))
+	m.ColorProfile = termenv.TrueColor
+	m.PageSize = 3
+	m.LoopCursor = true
+
+	test.Run(t, m, tea.KeyDown, tea.KeyDown, tea.KeyDown, tea.KeyDown)
+	assertNoError(t, m)
+
+	if strings.Contains(m.View(), firstElement) {
+		t.Fatalf("first element is already shown before looping")
+	}
+
+	// nolint:forcetypeassert
+	if value := getChoice(t, m).Value; value.(string) != lastElement {
+		t.Fatalf("value did not loop to the last element before looping but %q",
+			value)
+	}
+
+	test.Update(t, m, tea.KeyDown)
+
+	// nolint:forcetypeassert
+	if value := getChoice(t, m).Value; value.(string) != firstElement {
+		t.Fatalf("value did not loop to the first element %q but %q",
+			firstElement, value)
+	}
+
+	test.AssertGoldenView(t, m, "loop_bottom_to_top_paged.golden")
+}
+
 func getChoice(tb testing.TB, m *selection.Model) *selection.Choice {
 	tb.Helper()
 

--- a/selection/prompt.go
+++ b/selection/prompt.go
@@ -104,6 +104,10 @@ type Selection struct {
 	// pagination is always enabled when the prompt does not fit the terminal.
 	PageSize int
 
+	// LoopCursor enables the cursor to loop around to the first choice when
+	// navigating down from the last choice and the other way around.
+	LoopCursor bool
+
 	// Template holds the display template. A custom template can be used to
 	// completely customize the appearance of the selection prompt. If empty,
 	// the DefaultTemplate is used. The following variables and functions are

--- a/selection/testdata/loop_bottom_to_top.golden
+++ b/selection/testdata/loop_bottom_to_top.golden
@@ -1,0 +1,7 @@
+[1mfoo:[0m
+Filter: [7mT[0mype to filter choices
+  [38;5;32m[1m▸ [0m[0m[38;5;32;1mfirstelement[0m
+    b
+    c
+    d
+    lastelement

--- a/selection/testdata/loop_bottom_to_top_paged.golden
+++ b/selection/testdata/loop_bottom_to_top_paged.golden
@@ -1,0 +1,5 @@
+[1mfoo:[0m
+Filter: [7mT[0mype to filter choices
+  [38;5;32m[1m▸ [0m[0m[38;5;32;1mfirstelement[0m
+    b
+⇣   c

--- a/selection/testdata/loop_top_to_bottom.golden
+++ b/selection/testdata/loop_top_to_bottom.golden
@@ -1,0 +1,7 @@
+[1mfoo:[0m
+Filter: [7mT[0mype to filter choices
+    a
+    b
+    c
+    d
+  [38;5;32m[1m▸ [0m[0m[38;5;32;1mlastelement[0m

--- a/selection/testdata/loop_top_to_bottom_paged.golden
+++ b/selection/testdata/loop_top_to_bottom_paged.golden
@@ -1,0 +1,5 @@
+[1mfoo:[0m
+Filter: [7mT[0mype to filter choices
+⇡   c
+    d
+  [38;5;32m[1m▸ [0m[0m[38;5;32;1mlastelement[0m


### PR DESCRIPTION
This PR adds an option to loop the cursor to the last element when pressing up when the first element is selected and the other way around.