### PR TITLE
Fix for display of choices larger than the current window.

### DIFF
--- a/selection/model.go
+++ b/selection/model.go
@@ -76,10 +76,8 @@ func (m *Model[T]) Init() tea.Cmd {
 	}
 
 	m.filterInput = m.initFilterInput()
-
-	m.currentChoices, m.availableChoices = m.filteredAndPagedChoices()
-
 	m.requestedPageSize = m.PageSize
+	m.forceUpdatePageSizeForHeight()
 
 	return textinput.Blink
 }


### PR DESCRIPTION
Fix for display of choices larger than the current window.
    
It seems that the initial window height was not being taken in account during init and the choices were set to all choices and they overflowed giving a seemingly bad list until a filter was applied or the window was resized.

This calls `m.forceUpdatePageSizeForHeight()` on the model `Init()` which inits `m.currentChoices` and `m.availableChoices` correctly.
    
Fixes: #18